### PR TITLE
adding controls and increment buttons, separation of duties

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,9 +11,9 @@ class App extends Component {
 				partition: { maxReceiveRate: 3, maxTransmitRate: 3 },
 				consumer: { consumeRate: 4 },
 				layout: {
-					numProducers: 3,
-					numPartitions: 4,
-					numConsumers: 3
+					numProducers: 1,
+					numPartitions: 1,
+					numConsumers: 1
 				},
 				partitionBalanceStrategy: 'round-robin',
 				general: {

--- a/client/src/SimulatorController.js
+++ b/client/src/SimulatorController.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+class SimulatorController extends React.Component {
+	constructor(props) {
+		super();
+	}
+
+
+
+	render() {
+		//console.log("settings", this.props.settings)
+		// console.log("simulator controller current state", this.props.state)
+		const producerPropList = Object.keys(this.props.state.settings.producer).map((k) =>
+			<li><strong>{k}</strong>: {this.props.state.settings.producer[k]}</li>
+		)
+		const partitionPropList = Object.keys(this.props.state.settings.partition).map((k) =>
+			<li><strong>{k}</strong>: {this.props.state.settings.partition[k]}</li>
+		)
+		const consumerPropList = Object.keys(this.props.state.settings.consumer).map((k) =>
+			<li><strong>{k}</strong>: {this.props.state.settings.consumer[k]}</li>
+		)
+		return(
+			<div class="k-sim-control"> 
+					{ this.props.state.running && 
+						<button class="playback" onClick = {() => this.props.simControl('stop')}>stop</button>}
+					{ this.props.state.initialized && 
+						( this.props.state.running || 
+						<button class="playback" onClick = {() => this.props.simControl('play')}>play</button>)}
+					{ this.props.state.running ||
+						<button class="playback" onClick = {() => this.props.simControl('init')}>init</button>}
+					<br/>(tick: {this.props.state.tickNumber}/{this.props.state.maxTicks}) 
+				<div className="k-sim-settings">
+					<h2>Producer {' '}
+						<button onClick={() => this.props.simMutate([{actionType: 'create', simType: 'producer'}])}>+</button>
+					</h2>
+					<ul>{producerPropList}</ul>
+					<h2>Partition {' '}
+						<button onClick={() => this.props.simMutate([{actionType: 'create', simType: 'partition'}])}>+</button>
+					</h2>
+					<ul>{partitionPropList}</ul>
+					<h2>Consumer {' '}
+						<button onClick={() => this.props.simMutate([{actionType: 'create', simType: 'consumer'}])}>+</button>
+					</h2>	
+					<ul>{consumerPropList}</ul>
+				</div>
+			</div>
+
+		);
+	}
+}
+
+export default SimulatorController;


### PR DESCRIPTION
- Changed SimulatorSettings.js -> SimulatorController.js
- Default producers/partitions/consumers to 1
- Replaced consumer, partition, and consumer creation in initializeSimulator() with helper functions
- Beginning of separation of duties (model view controller)
    - simControl() non-mutating start, stop, reinit
    - ^passed to simulator controller, a child of simulator
    - simMutate() beginning of internal API to simulator
        - create, update, delete (read is one way with props)
        - update and delete outlined for future development
- Added rebalancing functions